### PR TITLE
Update x2b_example_user_config.toml

### DIFF
--- a/x2b_example_user_config.toml
+++ b/x2b_example_user_config.toml
@@ -4,6 +4,6 @@ mail-user = "example-user@brown.edu"
 mail-type = "ALL"
 
 [xnat2bids-args]
-session = "XNAT_E00080"
-includeseq=[1]
+sessions = ["XNAT_E00114"]
+includeseq=[6]
 


### PR DESCRIPTION
if the accession number isn't in a list, each letter gets launched as a separate job