### PR TITLE
Feat add dicom export and heudiconv capabilities

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -10,6 +10,7 @@ import pathlib
 import shlex
 import shutil
 import subprocess
+import sys
 from toml import load
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.NOTSET)
@@ -26,6 +27,17 @@ def fetch_latest_version():
     list_of_versions = glob.glob('/gpfs/data/bnc/simgs/brownbnc/*') 
     latest_version = max(list_of_versions, key=os.path.getctime)
     return (latest_version.split('-')[-1].replace('.sif', ''))
+
+def fetch_job_dependency_param():
+    job_ids = []
+    with open("launched_jobs.txt", "r") as f:
+        for line in f:
+            # Remove the "Submitted batch job " prefix from the line
+            job_number = line.replace("Submitted batch job ", "")
+            job_ids.append(job_number)
+
+    # Return afterok:{JOB-ID} for bids_postprocess to wait on heudiconv
+    return f"afterok:{job_ids[-1]}"
 
 def extract_params(param, value):
     arg = []
@@ -133,30 +145,6 @@ def compile_slurm_list(arg_dict, user):
             slurm_param_list.append(arg)
     return slurm_param_list
 
-def compile_xnat2bids_list(session, arg_dict, user):
-    """Create command line argument list from TOML dictionary."""
-
-    # Create copy of dictionary, so as not to update
-    # the original object reference while merging configs.
-    arg_dict_copy = copy.deepcopy(arg_dict) 
-
-    bindings = []
-    # Compile list of appended arguments
-    x2b_param_dict = {}
-    for section_name, section_dict in arg_dict_copy.items():
-        # Extract xnat2bids-args from original dictionary
-        if section_name == "xnat2bids-args":
-            x2b_param_dict = section_dict
-
-        # If a session key exist for the current session being 
-        # processed, update final config with session block. 
-        elif section_name == session:
-                x2b_param_dict.update(section_dict)
-    
-    # Transform session config dictionary into a parameter list.
-    xnat_tools_cmd, x2b_param_list = parse_x2b_params(x2b_param_dict, session, bindings)
-    return xnat_tools_cmd, x2b_param_list, bindings
-
 def compile_dcm2bids_list(arg_dict, d2b_bindings):
     d2b_param_list = []
     positional_arguments = ["project", "study", "bids_root"]
@@ -191,6 +179,30 @@ def compile_dcm2bids_list(arg_dict, d2b_bindings):
             d2b_param_list.append(arg)
 
     return d2b_param_list
+
+def compile_xnat2bids_list(session, arg_dict, user):
+    """Create command line argument list from TOML dictionary."""
+
+    # Create copy of dictionary, so as not to update
+    # the original object reference while merging configs.
+    arg_dict_copy = copy.deepcopy(arg_dict) 
+
+    bindings = []
+    # Compile list of appended arguments
+    x2b_param_dict = {}
+    for section_name, section_dict in arg_dict_copy.items():
+        # Extract xnat2bids-args from original dictionary
+        if section_name == "xnat2bids-args":
+            x2b_param_dict = section_dict
+
+        # If a session key exist for the current session being 
+        # processed, update final config with session block. 
+        elif section_name == session:
+                x2b_param_dict.update(section_dict)
+    
+    # Transform session config dictionary into a parameter list.
+    xnat_tools_cmd, x2b_param_list = parse_x2b_params(x2b_param_dict, session, bindings)
+    return xnat_tools_cmd, x2b_param_list, bindings
 
 async def main():
     # Instantiate argument parserß
@@ -320,8 +332,20 @@ async def main():
         # Add heudiconv command arguments to list for execution
         argument_lists.append(("xnat-heudiconv", d2b_param_list, heudiconv_slurm_params, dcm2bids_bindings))
 
+        # Define BIDS_EXPERIMENT_ROOT. Add bids_postprocess arguments to list for execution 
+        project_prefix = d2b_param_list[0].split("_")[0]
+        study_prefix = d2b_param_list[0].split("_")[1]
+        subject = d2b_param_list[1]
+        bids_experiment_dir = f"{bids_root}{project_prefix}/study-{study_prefix}/bids/"
+
+        postprocess_slurm_params = list(slurm_param_list)
+        add_job_name(postprocess_slurm_params, "bids_postprocess")
+
+        argument_lists.append(("bids-postprocess", [bids_experiment_dir, f"--user {user}", f"--pass {password}"], postprocess_slurm_params, dcm2bids_bindings))
+
     # Loop over argument lists for provided sessions.
     tasks = []
+    needs_dependency = False
     for args in argument_lists:
         # Compilie slurm and xnat2bids args 
         xnat_tools_cmd = args[0]
@@ -337,11 +361,18 @@ async def main():
             {xnat_tools_cmd} {xnat2bids_options}\nEOF\n)\""
 
         # Process command string for SRUN
-        sbatch_cmd = shlex.split(f"sbatch -Q {slurm_options} \
-            --wrap {sbatch_script}")    
+        if needs_dependency:
+            dependency_param = fetch_job_dependency_param()
+            sbatch_cmd = shlex.split(f"sbatch -d {dependency_param} {slurm_options} \
+                --wrap {sbatch_script}")    
+        else:
+            sbatch_cmd = shlex.split(f"sbatch {slurm_options} \
+                --wrap {sbatch_script}")    
+
+        print(sbatch_cmd)
 
         # Set logging level per session verbosity. 
-        set_logging_level(args[0])
+        set_logging_level(args[1])
 
         # Remove the password from sbatch command before logging 
         xnat2bids_options_without_password = []
@@ -359,21 +390,33 @@ async def main():
         sbatch_script_without_password = f"apptainer exec --no-home {bindings} {simg} \
                                             xnat2bids {xnat2bids_options_without_password}"
 
-        sbatch_cmd_without_password = shlex.split(f"sbatch -Q {slurm_options} \
+        sbatch_cmd_without_password = shlex.split(f"sbatch {slurm_options} \
                                                     --wrap {sbatch_script_without_password}")   
 
         logging.debug({
             "message": "Executing xnat2bids",
             "session": args[1][0],
-            "command": sbatch_cmd_without_password
+            "command": sbatch_cmd
         })
         
-        # Run xnat2bids asynchronously
-        task = asyncio.create_task(asyncio.create_subprocess_exec(*sbatch_cmd))
+        # Run xnat2bids asynchronously. Send stdout to launched_jobs.txt
+        f = open("launched_jobs.txt", "a")
+        task = asyncio.create_task(asyncio.create_subprocess_exec(*sbatch_cmd, stdout=f))
+
+        # If xnat-heudiconv, set dependency variable for bids_postprocess
+        needs_dependency = True if "xnat-heudiconv" in sbatch_cmd else False
+
+        # Wait for stdout to be flushed to launched_jobs.txt
+        if needs_dependency:
+            await asyncio.sleep(.5)
+
         tasks.append(task)
 
     # Wait for all subprocess tasks to complete
     await asyncio.gather(*tasks)
+
+    f.close()
+    os.remove("launched_jobs.txt")
 
     logging.info("Launched %d %s", len(tasks), "jobs" if len(tasks) > 1 else "job")
     logging.info("Processed Scans Located At: %s", bids_root)

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -327,11 +327,15 @@ async def main():
     for args in argument_lists:
         # Compilie slurm and xnat2bids args 
         xnat_tools_cmd = args[0]
-        xnat2bids_options = ' '.join(args[1])
-        slurm_options = ' '.join(args[2])
+        xnat2bids_param_list = args[1]
+        slurm_param_list = args[2]
+        bindings_paths = args[3]
+
+        xnat2bids_options = ' '.join(xnat2bids_param_list)
+        slurm_options = ' '.join(slurm_param_list)
 
         # Compile bindings into formated string
-        bindings = ' '.join(f"-B {path}" for path in args[3])
+        bindings = ' '.join(f"-B {path}" for path in bindings_paths)
 
         # Build shell script for sbatch
         sbatch_script = f"\"$(cat << EOF #!/bin/sh\n \
@@ -343,7 +347,7 @@ async def main():
             --wrap {sbatch_script}")    
 
         # Set logging level per session verbosity. 
-        set_logging_level(args[1])
+        set_logging_level(xnat2bids_param_list)
 
         # Remove the password from sbatch command before logging 
         xnat2bids_options_without_password = []
@@ -366,7 +370,7 @@ async def main():
 
         logging.debug({
             "message": "Executing xnat2bids",
-            "session": args[1][0],
+            "session": xnat2bids_param_list[0],
             "command": sbatch_cmd_without_password
         })
         

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -367,7 +367,7 @@ async def main():
         logging.debug({
             "message": "Executing xnat2bids",
             "session": args[1][0],
-            "command": sbatch_cmd
+            "command": sbatch_cmd_without_password
         })
         
         # Run xnat2bids asynchronously.

--- a/x2b_default_config.toml
+++ b/x2b_default_config.toml
@@ -3,7 +3,6 @@ time = "04:00:00"
 mem = 16000
 nodes = 1
 cpus-per-task = 2
-job-name = "xnat2bids"
 
 [xnat2bids-args]
 host="https://xnat.bnc.brown.edu"


### PR DESCRIPTION
# DICOM Export Only
Instead of creating a new config file section for sessions a user would like to solely export, I decided to add a new field: `export-only.`  A user can apply this to all sessions or define specific sessions to export.  

```
[xnat2bids-args]
sessions = ["XNAT_E00114"]
includeseq=[7,10]
skipseq=[6]
verbose=1
export-only=true
```

# DICOM to BIDS Conversion (Heudiconv)

The configuration setup is similar to launching the entire xnat2bids pipeline, with some minor differences and limitations.
Currently, this method of DICOM to BIDS conversion only services one session at time.  The following fields are required: project, subject, and session-suffix.  

**NOTE:** this does not launch bids_postprocess, as there is no way to control synchronization between asyncio and Slurm to coordinate Heudiconv's completion before launching bids_postprocessing.  `run_heudiconv` and `bids_postprocess` will be combined in a coming update to `xnat-tools`.  


```
[dcm2bids-args]
overwrite=true
project="bnc_demodat"
subject="005"
session-suffix="session1"
```

