### PR TITLE
refactor parsing x2b params and remove handling dicom-export and dcm2bids commands

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -198,9 +198,6 @@ async def main():
     # Assemble parameter lists per session
     argument_lists = []
 
-    # Compile list of slurm parameters.
-    slurm_param_list = compile_slurm_list(arg_dict, user)
-
     # Initialize bids_root for non-local use
     bids_root = f"/users/{user}/bids-export/"
 
@@ -211,6 +208,9 @@ async def main():
     # Compile parameter list per session for calls to xnat2bids
     if "sessions" in arg_dict['xnat2bids-args']:
         for session in arg_dict['xnat2bids-args']['sessions']:
+
+            # Compile list of slurm parameters.
+            slurm_param_list = compile_slurm_list(arg_dict, user)
 
             # Fetch compiled xnat2bids and slurm parameter lists
             x2b_param_list, bindings = compile_xnat2bids_list(session, arg_dict, user)

--- a/tests/test_xnat2bids.py
+++ b/tests/test_xnat2bids.py
@@ -1,48 +1,90 @@
 from toml import load
 import os
 import sys 
+import unittest
 sys.path.append(os.path.abspath("../"))
-from run_xnat2bids import compile_argument_list
+from run_xnat2bids import compile_xnat2bids_list, compile_slurm_list
+from run_xnat2bids import parse_x2b_params
 
-def test_xnat2bids():
-    # Load test parameters
-    test_params = load("/gpfs/data/bnc/shared/scripts/fmcdona4/oscar-scripts/tests/x2b_test_config.toml")
-    user = "test_user"
-    session = test_params['xnat2bids-args']['sessions'][0]
+
+class TestRunXnat2BIDS(unittest.TestCase):
+
+    def test_compile_x2b_lists(self):
+        # Load test parameters
+        test_params = load("/gpfs/data/bnc/shared/scripts/fmcdona4/oscar-scripts/tests/x2b_test_config.toml")
+        user = "test_user"
+        session = test_params['xnat2bids-args']['sessions'][0]
+        
+        # Initialize validation sets
+        x2b_validation_set = [
+        'XNAT_E00152', 
+        '/gpfs/data/bnc/shared/bids-export/', 
+        '--host https://xnat.bnc.brown.edu', 
+        '--bidsmap-file /gpfs/data/bnc/shared/scripts/fmcdona4/bidsmap.json',
+        '--includeseq 1 --includeseq 2', 
+        '--skipseq 3', 
+        '--overwrite']
+
+
+        slurm_validation_set = [
+            '--time 04:00:00', 
+            '--mem 16000', 
+            '--nodes 1', 
+            '--cpus-per-task 2', 
+            '--job-name xnat2bids', 
+            '--output /gpfs/scratch/%u/logs/xnat2bids_test%J.log', 
+            '--mail-user example-user@brown.edu', 
+            '--mail-type ALL']
+
+        bindings_validation_set = [
+            "/gpfs/data/bnc/shared/bids-export/",
+            "/gpfs/data/bnc/shared/scripts/fmcdona4/bidsmap.json"
+        ]
+
+        # Run compile_xnat2bids_list()
+        x2b_param_list, bindings = compile_xnat2bids_list(session, test_params, user)
     
-    # Initialize validation sets
-    x2b_validation_set = [
-    'XNAT_E00152', 
-    '/gpfs/data/bnc/shared/bids-export/', 
-    '--host https://xnat.bnc.brown.edu', 
-    '--session-suffix -1', 
-    '--bidsmap-file /gpfs/data/bnc/shared/scripts/fmcdona4/bidsmap.json',
-    '--includeseq 1 --includeseq 2', 
-    '--skipseq 3', 
-    '--overwrite']
+
+        self.assertEqual(x2b_param_list, x2b_validation_set)
+        self.assertEqual(bindings, bindings_validation_set)
+
+        # Run compile_slurm_list()      
+        slurm_param_list = compile_slurm_list(test_params, user)
+
+        self.assertEqual(slurm_param_list, slurm_validation_set)
 
 
-    slurm_validation_set = [
-        '--time 04:00:00', 
-        '--mem 16000', 
-        '--nodes 1', 
-        '--cpus-per-task 2', 
-        '--job-name xnat2bids', 
-        '--output /gpfs/scratch/%u/logs/xnat2bids_test%J.log', 
-        '--mail-user example-user@brown.edu', 
-        '--mail-type ALL']
+    def test_parse_x2b_params(self):
+        # Define test input data
+        xnat2bids_dict = {
+            "bids_root": "/path/to/bids",
+            "includeseq": ["t1w", "t2w"],
+            "export-only": True,
+            "verbose": 3,
+        }
+        session = "test_session"
+        bindings = []
 
-    bindings_validation_set = [
-        "/gpfs/data/bnc/shared/bids-export/",
-        "/gpfs/data/bnc/shared/scripts/fmcdona4/bidsmap.json"
-    ]
+        # Call the function being tested
+        result = parse_x2b_params(xnat2bids_dict, session, bindings)
 
-    # Run compileArgumentList()
-    x2b_param_list, slurm_param_list, bindings = compile_argument_list(session, test_params, user)
-    assert x2b_param_list == x2b_validation_set
-    assert slurm_param_list == slurm_validation_set
-    assert bindings == bindings_validation_set
+        # Define the expected output
+        expected_result = [
+            "test_session",
+            "/path/to/bids",
+            "--includeseq t1w --includeseq t2w",
+            "--export-only",
+            "--verbose",
+            "--verbose",
+            "--verbose",
+        ]
+        expected_bindings = ["/path/to/bids"]
+
+        # Check that the result matches the expected output
+        self.assertEqual(result, expected_result)
+        self.assertEqual(bindings, expected_bindings)
+
 
 if __name__ == "__main__":
-    test_xnat2bids()
+    unittest.main()
     

--- a/tests/test_xnat2bids.py
+++ b/tests/test_xnat2bids.py
@@ -3,7 +3,7 @@ import os
 import sys 
 import unittest
 sys.path.append(os.path.abspath("../"))
-from run_xnat2bids import compile_xnat2bids_list, compile_slurm_list
+from run_xnat2bids import compile_xnat2bids_list, compile_slurm_list, extract_params
 from run_xnat2bids import parse_x2b_params
 
 
@@ -84,6 +84,37 @@ class TestRunXnat2BIDS(unittest.TestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(bindings, expected_bindings)
 
+    def test_extract_params_list(self):
+        # Test extraction of list input
+        param = "includeseq"
+        value = [1, 2, 3, 4]
+        result = extract_params(param, value)
+        expected_result = "--includeseq 1 --includeseq 2 --includeseq 3 --includeseq 4"
+        self.assertEqual(result, expected_result)
+
+    def test_extract_params_range(self):
+        # Test extraction of range input
+        param = "includeseq"
+        value = "1-4, 7, 10"
+        result = extract_params(param, value)
+        expected_result = "--includeseq 1 --includeseq 2 --includeseq 3 --includeseq 4 --includeseq 7 --includeseq 10"
+        self.assertEqual(result, expected_result)
+
+    def test_extract_params_skipseq(self):
+        # Test extraction of skipseq input
+        param = "skipseq"
+        value = "3-5, 7"
+        result = extract_params(param, value)
+        expected_result = "--skipseq 3 --skipseq 4 --skipseq 5 --skipseq 7"
+        self.assertEqual(result, expected_result)
+
+    def test_extract_params_empty(self):
+        # Test extraction of empty input
+        param = "includeseq"
+        value = []
+        result = extract_params(param, value)
+        expected_result = ""
+        self.assertEqual(result, expected_result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/x2b_test_config.toml
+++ b/tests/x2b_test_config.toml
@@ -13,7 +13,6 @@ sessions = ["XNAT_E00152"]
 bids_root = "/gpfs/data/bnc/shared/bids-export/"
 version = ""
 host="https://xnat.bnc.brown.edu"
-session-suffix=-1
 bidsmap-file="/gpfs/data/bnc/shared/scripts/fmcdona4/bidsmap.json"
 includeseq=[1,2]
 skipseq=[3]

--- a/x2b_default_config.toml
+++ b/x2b_default_config.toml
@@ -3,6 +3,7 @@ time = "04:00:00"
 mem = 16000
 nodes = 1
 cpus-per-task = 2
+job-name = "xnat2bids"
 
 [xnat2bids-args]
 host="https://xnat.bnc.brown.edu"


### PR DESCRIPTION
## Refactor xnat2bids Parameter Parsing Function 

parse_x2b_params() now checks each parameter against a pre-defined set of valid parameters and their types (see below), and constructs a list of arguments to be passed to a command-line utility.  For future / new arguments, simply add to the xnat2bids_params list with the following format: `name: (parameter_type, needs_binding)`

```
xnat2bids_params = {
    "bids_root": (ParamType.PARAM_VAL, True),
    "bidsmap-file": (ParamType.PARAM_VAL, True),
    "host": (ParamType.PARAM_VAL, False),
    "log-id": (ParamType.PARAM_VAL, False),
    "version": (ParamType.PARAM_VAL, False),
    "includeseq": (ParamType.MULTI_VAL, False),
    "skipseq": (ParamType.MULTI_VAL, False),
    "export-only": (ParamType.FLAG_ONLY, False),
    "overwrite": (ParamType.FLAG_ONLY, False),
    "skip-export": (ParamType.FLAG_ONLY, False),
    "verbose": (ParamType.MULTI_FLAG, False),
}  
```

## Remove dicom-export and dcm2bids

The `xnat2bids` interface in xnat-tools has been updated to recieve `--export-only` and `--skip-export` flags to run the component parts of the pipeline. Now, we only need to call `xnat2bids` with the respective flags, rather than `xnat-dicom-export` or `xnat-dcm2bids` to do so.  