### PR TITLE
fix: create bids_root if it doesn't exist

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -264,7 +264,7 @@ async def main():
                 output = arg_dict['slurm-args']['output']
 
             if not (os.path.exists(os.path.dirname(output))):
-                os.mkdir(os.path.dirname(output))
+                os.makedirs(os.path.dirname(output))
 
             add_job_name(slurm_param_list, "xnat2bids")
 
@@ -276,7 +276,7 @@ async def main():
             bindings.append(bids_root)
 
             if not (os.path.exists(bids_root)):
-                os.mkdir(bids_root)  
+                os.makedirs(bids_root)  
 
             # Store xnat2bids, slurm, and binding paramters as tuple.
             argument_lists.append((xnat_tools_cmd, x2b_param_list, slurm_param_list, bindings))

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -275,8 +275,8 @@ async def main():
             x2b_param_list.insert(1, bids_root)
             bindings.append(bids_root)
 
-            if not (os.path.exists(os.path.dirname(bids_root))):
-                os.mkdir(os.path.dirname(bids_root))  
+            if not (os.path.exists(bids_root)):
+                os.mkdir(bids_root)  
 
             # Store xnat2bids, slurm, and binding paramters as tuple.
             argument_lists.append((xnat_tools_cmd, x2b_param_list, slurm_param_list, bindings))


### PR DESCRIPTION
fix previous error where bids_root was being treated as a filename not a directory, so the script was checking whether one level up existed, not whether the bids_root directory itself existed