### PR TITLE
add bids-validator to run_xnat2bids

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -458,8 +458,14 @@ async def main():
         validator_output = await launch_bids_validator(arg_dict, user, password, bids_root, jobs)
         update_jobs(jobs, validator_output)
 
-    logging.info("Launched %d %s", len(jobs), "jobs" if len(jobs) > 1 else "job")
-    logging.info("Job %s: %s", "IDs" if len(jobs) > 1 else "ID", ' '.join(jobs))
+    # Summary Logging 
+    logging.info("Launched %d xnat2bids %s", len(jobs)-1, "jobs" if len(jobs)-1 > 1 else "job")
+    logging.info("Job %s: %s", "IDs" if len(jobs)-1 > 1 else "ID", ' '.join(jobs[:-1]))
+
+    if needs_validation:
+        logging.info("Launched bids-validator to check BIDS compliance")
+        logging.info("Job ID: %s", jobs[-1])
+
     logging.info("Processed Scans Located At: %s", bids_root)
 
 if __name__ == "__main__":

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -459,12 +459,15 @@ async def main():
         update_jobs(jobs, validator_output)
 
     # Summary Logging 
-    logging.info("Launched %d xnat2bids %s", len(jobs)-1, "jobs" if len(jobs)-1 > 1 else "job")
-    logging.info("Job %s: %s", "IDs" if len(jobs)-1 > 1 else "ID", ' '.join(jobs[:-1]))
-
     if needs_validation:
+        logging.info("Launched %d xnat2bids %s", len(jobs)-1, "jobs" if len(jobs)-1 > 1 else "job")
+        logging.info("Job %s: %s", "IDs" if len(jobs)-1 > 1 else "ID", ' '.join(jobs[:-1]))
         logging.info("Launched bids-validator to check BIDS compliance")
         logging.info("Job ID: %s", jobs[-1])
+    else:
+        logging.info("Launched %d xnat2bids %s", len(jobs), "jobs" if len(jobs) > 1 else "job")
+        logging.info("Job %s: %s", "IDs" if len(jobs) > 1 else "ID", ' '.join(jobs))
+
 
     logging.info("Processed Scans Located At: %s", bids_root)
 

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -252,7 +252,7 @@ def compile_xnat2bids_list(session, arg_dict, user):
     return x2b_param_list, bindings
 
 def assemble_argument_lists(arg_dict, user, password, bids_root, argument_lists=[]):
-
+    # Compose argument lists for each session 
     for session in arg_dict['xnat2bids-args']['sessions']:
 
         # Compile list of slurm parameters.
@@ -440,13 +440,13 @@ async def main():
     if "sessions" in arg_dict['xnat2bids-args']:
         argument_lists = assemble_argument_lists(arg_dict, user, password, bids_root)
 
-    # Loop over argument lists for provided sessions.
+    # Launch xnat2bids
     x2b_output = await launch_x2b_jobs(argument_lists, simg)
     jobs = fetch_job_ids(x2b_output)
 
-    # Run bids-validator
+    # Launch bids-validator
     validator_output = await launch_bids_validator(arg_dict, user, password, bids_root, jobs)
-    fetch_job_ids(validator_output)
+    jobs = fetch_job_ids(validator_output)
 
     logging.info("Launched %d %s", len(jobs), "jobs" if len(jobs) > 1 else "job")
     logging.info("Job %s: %s", "IDs" if len(jobs) > 1 else "ID", ' '.join(jobs))

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -325,9 +325,9 @@ async def launch_x2b_jobs(argument_lists, simg, tasks=[], output=[]):
         if "--export-only" not in xnat2bids_param_list: needs_validation = True 
 
         # Build shell script for sbatch
-        sbatch_script = f"\"$(cat << EOF #!/bin/sh\n \
+        sbatch_script = f'\'$(cat << EOF #!/bin/sh\n \
             apptainer exec --no-home {bindings} {simg} \
-            xnat2bids {xnat2bids_options}\nEOF\n)\""
+            xnat2bids {xnat2bids_options}\nEOF\n)\''
 
         # Process command string for SRUN
         sbatch_cmd = shlex.split(f"sbatch {slurm_options} \
@@ -382,6 +382,9 @@ async def launch_bids_validator(arg_dict, user, password, bids_root, job_deps):
     proj, subj = get_project_subject_session(connection, host, session)
     pi_prefix, study_prefix = prepare_path_prefixes(proj, subj)
 
+    # Close connection
+    connection.close()
+    
     # Define bids-validator singularity image path
     simg=f"/gpfs/data/bnc/simgs/bids/validator-latest.sif"
 

--- a/x2b_default_config.toml
+++ b/x2b_default_config.toml
@@ -3,6 +3,7 @@ time = "04:00:00"
 mem = 16000
 nodes = 1
 cpus-per-task = 2
+job-name = "xnat2bids"
 
 [xnat2bids-args]
 host="https://xnat.bnc.brown.edu"


### PR DESCRIPTION
# Integrate BIDS Validator 

## Establishing Synchronization
This PR introduces BIDS validation into the `run_xnat2bids` script.  I am utilizing Slurm's job dependency capability to ensure that all `xnat2bids` processes finish before launching `bids-validator`.  To do this, I route stdout to a pipe, wait for the process to complete, and parse the bytes returned from Process.communicate(). 

```
  # Run xnat2bids 
  proc = await asyncio.create_subprocess_exec(*sbatch_cmd, stdout=asyncio.subprocess.PIPE)

  stdout, stderr = await proc.communicate()
  output.append(stdout)
```

The list of output statements to stdout is then parsed into a list of JOB-IDs by the function below, `fetch_job_ids`, which I then pass into `sbatch -d afterok:[JOB-IDs] bids-validator`. 

```
def fetch_job_ids(stdout, jobs = []):
    if isinstance(stdout, bytes):
        stdout = [stdout]

    for line in stdout:
        job_id = line.replace(b'Submitted batch job ', b'' ).strip().decode('utf-8')
        jobs.append(job_id)

    return jobs
```

**NOTE:**  File IO and `asyncio.sleep(1)` are no longer used as the method for retrieving JOB-IDs.

## Defining the BIDS Experiment Path

Since all of the jobs are launched simultaneously, one issue I ran into was pre-defining the BIDS_EXPERIMENT_DIR before that path had been created by the sibling xnat2bids jobs.  The only way I could resolve this was to make a request to XNAT via the Accession ID for the PI and Study prefixes in order to construct the path `/bids_root/pi_prefix/study_prefix/bids`.

I borrowed a lot of code from `xnat-tools` to do this.  While I'm not a fan of the duplication, I'm not aware of another method to forecast the necessary path variables other than getting them from XNAT directly.  

