### PR TITLE
Fix bids val output and kill on invalid

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -401,6 +401,7 @@ async def launch_bids_validator(arg_dict, user, password, bids_root, job_deps):
     output = f"/gpfs/scratch/{user}/logs/%x-%J.txt"
     arg = f"--output {output}"
     bids_val_slurm_params.append(arg)
+    bids_val_slurm_params.append("--kill-on-invalid-dep=yes")
     slurm_options = ' '.join(bids_val_slurm_params)
 
     # Process command string for SRUN

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -398,8 +398,10 @@ async def launch_bids_validator(arg_dict, user, password, bids_root, job_deps):
 
     # Compile list of slurm parameters.
     bids_val_slurm_params = compile_slurm_list(arg_dict, user)
-    output = f"/gpfs/scratch/{user}/logs/%x-%J.txt"
-    arg = f"--output {output}"
+    if not ('output' in bids_val_slurm_params):
+        output = f"/gpfs/scratch/{user}/logs/%x-%J.txt"
+        arg = f"--output {output}"
+        bids_val_slurm_params.append(arg)
     bids_val_slurm_params.append(arg)
     bids_val_slurm_params.append("--kill-on-invalid-dep=yes")
     slurm_options = ' '.join(bids_val_slurm_params)

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -398,11 +398,16 @@ async def launch_bids_validator(arg_dict, user, password, bids_root, job_deps):
 
     # Compile list of slurm parameters.
     bids_val_slurm_params = compile_slurm_list(arg_dict, user)
-    if not ('output' in bids_val_slurm_params):
-        output = f"/gpfs/scratch/{user}/logs/%x-%J.txt"
-        arg = f"--output {output}"
+    if not ('output' in arg_dict['slurm-args']):
+        val_output = f"/gpfs/scratch/{user}/logs/%x-%J.txt"
+        arg = f"--output {val_output}"
         bids_val_slurm_params.append(arg)
-    bids_val_slurm_params.append(arg)
+    else:
+        x2b_output = arg_dict['slurm-args']['output'].split("/")
+        x2b_output[-1] = "%x-%J.txt"
+        val_output = "/".join(x2b_output)
+        bids_val_slurm_params = [f"--output {val_output}" if "output" in item else item for item in bids_val_slurm_params]
+
     bids_val_slurm_params.append("--kill-on-invalid-dep=yes")
     slurm_options = ' '.join(bids_val_slurm_params)
 


### PR DESCRIPTION
Add kill on invalid dependency flag to bids validator slurm command, so that the job is automatically killed if the xnat2bids jobs fail. Also, if the user specifies a slurm output file, use this output directory for the bids validator output file as well as the xnat2bids slurm output.