### PR TITLE
fetch sessions by project and subject id

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -34,18 +34,22 @@ class ParamType(Enum):
 
 # param_name: (param_type, needs_binding)
 xnat2bids_params = {
-    "bids_root": (ParamType.PARAM_VAL, True),
     "bidsmap-file": (ParamType.PARAM_VAL, True),
-    "host": (ParamType.PARAM_VAL, False),
-    "log-id": (ParamType.PARAM_VAL, False),
-    "version": (ParamType.PARAM_VAL, False),
-    "includeseq": (ParamType.MULTI_VAL, False),
-    "skipseq": (ParamType.MULTI_VAL, False),
+    "bids_root": (ParamType.PARAM_VAL, True),
+    "cleanup": (ParamType.FLAG_ONLY, False),
     "export-only": (ParamType.FLAG_ONLY, False),
+    "host": (ParamType.PARAM_VAL, False),
+    "includeseq": (ParamType.MULTI_VAL, False),
+    "log-id": (ParamType.PARAM_VAL, False),
     "overwrite": (ParamType.FLAG_ONLY, False),
+    "project": (ParamType.PARAM_VAL, False),
+    "sessions": (ParamType.MULTI_VAL, False),
     "skip-export": (ParamType.FLAG_ONLY, False),
+    "skipseq": (ParamType.MULTI_VAL, False),
+    "subjects": (ParamType.MULTI_VAL, False),
+    "version": (ParamType.PARAM_VAL, False),
     "verbose": (ParamType.MULTI_FLAG, False),
-} 
+}
 
 def get_user_credentials():
     user = input('Enter XNAT Username: ')
@@ -182,6 +186,8 @@ def fetch_job_ids(stdout):
     return jobs
 
 def fetch_requested_sessions(arg_dict, user, password):
+    # Initialize sessions list
+    sessions = []
 
     # Establish connection 
     connection = requests.Session()
@@ -249,7 +255,9 @@ def parse_x2b_params(xnat2bids_dict, session, bindings):
 
     for param, value in xnat2bids_dict.items():
         if param not in xnat2bids_params:
-            continue
+            logging.info(f"Invalid parameter {param} in configuration file.")
+            logging.info("Please resolve invalid parameters before running.")
+            exit()
         if value == "" or value is  None:
             continue
         if param in positional_args:

--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -98,9 +98,8 @@ def get_project_subject_session(connection, host, session):
 
 def get_sessions_from_project_subjects(connection, host, project, subjects):
     sessions = []
+
     for subj in subjects:
-        print("------------------------------------------------")
-        print("Get projects information")
         r = get(
             connection,
             host + f"/data/projects/{project}/subjects/{subj}/experiments",
@@ -109,11 +108,10 @@ def get_sessions_from_project_subjects(connection, host, project, subjects):
         projectValues = r.json()["ResultSet"]["Result"]
         sessions.extend(extractSessions(projectValues))
 
-        return sessions
+    return sessions
 
 def get_sessions_from_project(connection, host, project):
-    print("------------------------------------------------")
-    print("Get projects information: ", project)
+
     r = get(
         connection,
         host + f"/data/projects/{project}/experiments",


### PR DESCRIPTION
This PR allows the user to execute `xnat2bids` across all experiments that exist beneath a project(s) / subject(s) ID.  

- If only a project ID is specified, all sessions contained in that project will be processed.
- If a list of subject IDs is specified, only sessions from those participants will be processed.
- Individual sessions can still be specified inside the `sessions` list.  

```
[xnat2bids-args]
project = "BNC_DEMODAT"
subjects=["001", "002", "003"]
sessions=["XNAT_E00474"]
```

NOTE:

- If `subjects` is populated inside the configuration file, a project ID must be present.
- Currently, only one project can be specified at a time. However, if a session is provided in `sessions` list that exist outside the listed project, `run_xnat2bids` will process those sessions and kick off a separate call to `bids-validator` for their bids experiment path.  
- The issue with listing multiple projects is the inability to map listed subject IDs to their associated project ID.  If BNC wants this feature, I can tackle this in another PR.