### PR TITLE
increase job memory to 32GB

### DIFF
--- a/singularity-sync.sh
+++ b/singularity-sync.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #SBATCH --time=24:00:00
-#SBATCH --mem=8G
+#SBATCH --mem=32G
 #SBATCH -J SingularitySync
 #SBATCH -o /gpfs/scratch/%u/SingularitySync-%j.out
 


### PR DESCRIPTION
singularity-sync gets killed with oom error - we were only requesting 8GB