### PR TITLE
fix: only add flag to xnat-tools call if true in toml file

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -389,8 +389,10 @@ def parse_x2b_params(xnat2bids_dict, session, bindings):
             arg = extract_params(param, value)
             x2b_param_list.append(arg)
         elif param_type == ParamType.FLAG_ONLY:
-            arg = f"--{param}"
-            x2b_param_list.append(arg)
+            # only add this flag if true in toml
+            if value:
+                arg = f"--{param}"
+                x2b_param_list.append(arg)
         elif param_type == ParamType.MULTI_FLAG:
             arg = f"--{param}"
             for i in range(value):


### PR DESCRIPTION
Previously, the value in the toml file was ignored, so setting overwrite=false or validate-frames=false would pass --overwrite and --validate_frames to xnat-tools. Now if the parameter is not included in the toml file, or is set to false, it will not be passed as a flag to xnat-tools.