### PR TITLE
fix: error if both project and XNAT sessions are present in toml file

### DIFF
--- a/run_xnat2bids.py
+++ b/run_xnat2bids.py
@@ -94,6 +94,10 @@ def verify_parameters(config):
         logging.error("Both subjects and sessions are defined in configuration file.")
         logging.error("Please specify with either (project & subject) OR session (XNAT Accession #)")
         exit()
+    elif 'project' in x2b_params.keys() and 'sessions' in x2b_params.keys():
+        logging.error("Both project and sessions are defined in configuration file.")
+        logging.error("Please specify with either (project & subject) OR session (XNAT Accession #)")
+        exit()
 
 def get_user_credentials():
     user = input('Enter XNAT Username: ')


### PR DESCRIPTION
If both are present, the sessions list gets ignored and all sessions for the project are converted, which is unlikely to be the desired behavior if sessions are specified. Instead just error:

Both project and sessions are defined in configuration file. Please specify with either (project & subject) OR session (XNAT Accession #)